### PR TITLE
Add standalone live demo page using shared controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,87 @@
-# Vitals Live — Demo de Venta
+# OpenVitals Monitor
 
-> **Objetivo:** mostrar el producto (pulso + estrés con cámara) sin revelar todas las capacidades. Ideal para demos a clientes o inversores.
+OpenVitals Monitor is a lightweight web experience that demonstrates camera-based vital sign extraction without any proprietary branding. It includes a reusable JavaScript SDK (`sdk.js`) so you can embed remote photoplethysmography (rPPG) capture inside your own applications.
 
-## Contenido
-- `index.html`: landing + modal con **Demo en Vivo** (pulso y estrés).
-- `presentation.html`: **presentación** navegable con flechas ⇦ ⇨.
-- `styles.css`, `app.js`: estilos y lógica de medición (rPPG).
-- `manifest.webmanifest`, `sw.js`: PWA básica (instalable).
-- `assets/logo.svg`: logo simple.
+The demo highlights:
 
-## Requisitos
-- **HTTPS o `localhost`** para acceder a la cámara (requisito de navegador).
-- Navegadores soportados: Chrome/Edge/Firefox (desktop y Android), Safari (iOS).
-- **No médico**: precisión dependiente de luz, movimiento y calidad de cámara.
+- **Heart rate** derived from per-frame skin color fluctuations.
+- **Stress index** computed from short-term heart-rate variability (RMSSD).
+- **Respiratory trend** estimated from the low-frequency component of the signal.
+- **Signal quality feedback** so operators can guide users in real time.
 
-## Ejecutar en local
-1. Descarga y descomprime el zip.
-2. En la carpeta del proyecto, ejecuta **uno** de estos:
+> ⚠️ This project is for wellness, experimentation and research. It is **not** a medical device and does not provide diagnoses.
+
+## Project structure
+
+| File | Description |
+| --- | --- |
+| `index.html` | Landing page + live capture modal. |
+| `demo.html` | Standalone page that runs the live capture experience. |
+| `app.js` | Landing page modal wiring built on the shared controller. |
+| `demo.js` | Entry file for the standalone demo page. |
+| `vitals-demo.js` | Reusable UI controller that connects DOM elements to the SDK. |
+| `sdk.js` | Standalone CameraVitalsSDK implementation. |
+| `styles.css` | Shared styling for the landing page, modal and demo page. |
+| `manifest.webmanifest`, `sw.js` | Minimal PWA setup for install/offline caching. |
+
+## Running locally
+
+1. Serve the folder over HTTPs or `localhost` (camera access is restricted otherwise). Examples:
    - Python 3: `python -m http.server 8000`
-   - Node: `npx http-server`
-3. Abre `http://localhost:8000` y pulsa **Demo en vivo** → **Iniciar**.
-4. En iPhone/Android: abre el sitio en **HTTPS** o en `localhost` para que funcione la cámara.
+   - Node.js: `npx http-server`
+2. Open `http://localhost:8000` in Chrome, Edge or Safari.
+3. Either:
+   - Click **Launch live capture** → **Start** in the modal, or
+   - Navigate to [`/demo.html`](demo.html) for the fullscreen demo experience.
+   Keep your face still for ~20 seconds while the signal calibrates.
 
-## Publicar rápido
-- **Netlify**: arrastra y suelta la carpeta (obtendrás un URL HTTPS).
-- **GitHub Pages**: activa Pages en el repo (branch `main`).
+For iOS/Android devices open the site via HTTPS (or `localhost` if debugging) to allow the browser to access the camera.
 
-## Notas de demo
-- Muestra **Pulso (BPM)** y **Estrés (0–100)**. Métricas “Pro” quedan bloqueadas visualmente.
-- ROI (rectángulo) sugiere al usuario alinear la frente.
-- No se sube el video. El cálculo ocurre en el dispositivo.
+## SDK quick start
 
-## Limitaciones
-- La señal puede degradarse con mala iluminación o movimiento.
-- HRV/respiración no se muestran en esta demo (quedan para versión Pro).
+```js
+import { CameraVitalsSDK } from './sdk.js';
 
-## Licencia
-MIT (demo).
+const sdk = new CameraVitalsSDK({
+  videoElement: document.querySelector('#video'),
+  overlayCanvas: document.querySelector('#overlay'),
+});
+
+const cameras = await sdk.listCameras({ requestAccess: true });
+await sdk.start({ deviceId: cameras[0]?.deviceId });
+
+sdk.addEventListener('metrics', (event) => {
+  const { heartRate, stressScore, breathingRate, hrvMs, signalQuality } = event.detail;
+  console.log({ heartRate, stressScore, breathingRate, hrvMs, signalQuality });
+});
+```
+
+### Events
+
+- `metrics` → Fired roughly 3× per second with the latest readings.
+- `status` → Textual updates (requesting permission, calibrating, capturing, etc.).
+- `error` → When something goes wrong (permission denied, unsupported browser…).
+- `cameralist` → Emitted after `listCameras()` resolves.
+
+### Methods
+
+- `listCameras({ requestAccess })` → Returns available `MediaDeviceInfo` camera entries. Set `requestAccess` to `true` to proactively ask for permission so device labels are populated.
+- `start({ deviceId })` → Requests `getUserMedia`, plays the provided video element and starts sampling.
+- `stop()` → Stops the camera, clears buffers and detaches resize listeners.
+
+Each `metrics` event includes:
+
+- `heartRate` (bpm) if stable peaks are detected.
+- `stressScore` (0–100) mapped from RMSSD.
+- `hrvMs` (ms) rounded RMSSD.
+- `breathingRate` (rpm) based on slow oscillations.
+- `signalQuality` (0–1) from the filter amplitude.
+- `beatPhase` (0–1) estimating time since the last beat.
+
+## Deployment
+
+Any static hosting service (GitHub Pages, Netlify, Vercel, S3+CloudFront, etc.) works—just ensure the site is served over HTTPS.
+
+## License
+
+MIT.

--- a/app.js
+++ b/app.js
@@ -1,271 +1,67 @@
-// Minimal demo app: rPPG (cara), HR + Estrés estimado. No médico.
-(() => {
-  // Elements
-  const btnOpenDemo = document.getElementById('btnOpenDemo');
-  const btnOpenDemo2 = document.getElementById('btnOpenDemo2');
-  const btnOpenDemo3 = document.getElementById('btnOpenDemo3');
-  const modal = document.getElementById('demoModal');
-  const btnCloseDemo = document.getElementById('btnCloseDemo');
-  const btnStart = document.getElementById('btnStart');
-  const btnStop = document.getElementById('btnStop');
-  const cameraSelect = document.getElementById('cameraSelect');
-  const video = document.getElementById('video');
-  const overlay = document.getElementById('overlay');
-  const roiDiv = document.getElementById('roi');
-  const hrEl = document.getElementById('hrVal');
-  const stressEl = document.getElementById('stressVal');
-  const stressBadge = document.getElementById('stressBadge');
-  const pulseDot = document.getElementById('pulseDot');
-  const statusEl = document.getElementById('status');
+import { VitalsDemo } from './vitals-demo.js';
 
-  const openDemo = () => { modal.classList.add('show'); };
-  const closeDemo = () => { modal.classList.remove('show'); stopMeasurement(); };
+const modal = document.getElementById('demoModal');
+const btnOpenDemo = document.getElementById('btnOpenDemo');
+const btnOpenDemo2 = document.getElementById('btnOpenDemo2');
+const btnCloseDemo = document.getElementById('btnCloseDemo');
+const btnStart = document.getElementById('btnStart');
+const btnStop = document.getElementById('btnStop');
+const cameraSelect = document.getElementById('cameraSelect');
+const video = document.getElementById('video');
+const overlay = document.getElementById('overlay');
+const hrEl = document.getElementById('hrVal');
+const stressEl = document.getElementById('stressVal');
+const stressBadge = document.getElementById('stressBadge');
+const hrvEl = document.getElementById('hrvVal');
+const rrEl = document.getElementById('rrVal');
+const statusEl = document.getElementById('status');
+const qualityEl = document.getElementById('quality');
+const pulseDot = document.getElementById('pulseDot');
 
-  btnOpenDemo?.addEventListener('click', openDemo);
-  btnOpenDemo2?.addEventListener('click', openDemo);
-  btnOpenDemo3?.addEventListener('click', openDemo);
-  btnCloseDemo?.addEventListener('click', closeDemo);
+const demoController = new VitalsDemo({
+  videoElement: video,
+  overlayCanvas: overlay,
+  startButton: btnStart,
+  stopButton: btnStop,
+  cameraSelect,
+  hrEl,
+  stressEl,
+  stressBadge,
+  hrvEl,
+  rrEl,
+  statusEl,
+  qualityEl,
+  pulseDot,
+});
 
-  // Camera state
-  let stream = null, track = null, running = false, rafId = null;
-  const ctx = overlay.getContext('2d');
+function openDemo() {
+  modal.classList.add('show');
+  demoController.reset();
+  demoController.refreshCameras();
+}
 
-  // Buffers
-  const times=[], rawVals=[], filtVals=[], breathVals=[], peakTimes=[];
-  const MAX_SECONDS=20, MIN_IBI=0.33, MAX_IBI=1.5;
+async function closeDemo() {
+  modal.classList.remove('show');
+  await demoController.stop();
+  demoController.reset();
+}
 
-  // Filters state
-  const bpState = { hp:0, lp:0, prev:0 };
-  const brState = { lp:0 };
+btnOpenDemo?.addEventListener('click', openDemo);
+btnOpenDemo2?.addEventListener('click', openDemo);
+btnCloseDemo?.addEventListener('click', closeDemo);
 
-  // Helpers
-  function fitCanvas(){ overlay.width = video.clientWidth; overlay.height = video.clientHeight; }
-  window.addEventListener('resize', fitCanvas);
-
-  async function listCameras(){
-    cameraSelect.innerHTML = '';
-    const devices = await navigator.mediaDevices.enumerateDevices();
-    const cams = devices.filter(d => d.kind === 'videoinput');
-    const preferred = cams.find(d => /front|user|frontal/i.test(d.label)) || cams[0];
-    cams.forEach((d,i)=>{
-      const opt=document.createElement('option');
-      opt.value=d.deviceId; opt.textContent=d.label || `Cámara ${i+1}`;
-      cameraSelect.appendChild(opt);
-    });
-    if (preferred) cameraSelect.value = preferred.deviceId;
+modal?.addEventListener('click', (event) => {
+  if (event.target === modal) {
+    closeDemo();
   }
+});
 
-  async function startCamera(){
-    if (stream) stopCamera();
-    const deviceId = cameraSelect.value || undefined;
-    const facingMode = deviceId ? undefined : 'user';
-    stream = await navigator.mediaDevices.getUserMedia({
-      audio:false,
-      video:{ width:{ideal:1280}, height:{ideal:720}, frameRate:{ideal:30,max:60},
-              deviceId: deviceId ? {exact:deviceId} : undefined, facingMode }
-    });
-    video.srcObject = stream;
-    track = stream.getVideoTracks()[0];
-    await video.play();
-    fitCanvas();
-
-    // Mirror if front camera
-    try {
-      const s = track.getSettings?.() || {};
-      const isFront = (s.facingMode === 'user' || s.facingMode === 'front');
-      video.style.transform = isFront ? 'scaleX(-1)' : 'none';
-    } catch(e){/*noop*/}
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && modal.classList.contains('show')) {
+    closeDemo();
   }
-  function stopCamera(){
-    if (stream) { stream.getTracks().forEach(t=>t.stop()); stream=null; track=null; }
-  }
+});
 
-  // Simple filters
-  function bandpass(v, dt, s){
-    const fcHP=0.7, rcHP=1/(2*Math.PI*fcHP), aHP=rcHP/(rcHP+dt);
-    s.hp = aHP*(s.hp + v - s.prev); s.prev = v;
-    const fcLP=3.0, rcLP=1/(2*Math.PI*fcLP), aLP=dt/(rcLP+dt);
-    s.lp = s.lp + aLP*(s.hp - s.lp);
-    return s.lp;
-  }
-  function lowpass(v, dt, s, fc=0.35){
-    const rc=1/(2*Math.PI*fc), a=dt/(rc+dt); s.lp = s.lp + a*(v - s.lp); return s.lp;
-  }
-  function detectPeaks(series, timeSeries, minDist){
-    const n=series.length; if(n<5) return [];
-    const mean=series.reduce((a,b)=>a+b,0)/n;
-    const sd=Math.sqrt(series.reduce((a,b)=>a+(b-mean)*(b-mean),0)/n)||1;
-    const thr=mean+0.5*sd;
-    const peaks=[];
-    for(let i=2;i<n-2;i++){
-      const v=series[i];
-      if(v>thr && v>series[i-1] && v>series[i+1] && v>=series[i-2] && v>=series[i+2]){
-        const t=timeSeries[i];
-        if(!peaks.length || (t - peaks[peaks.length-1]) >= minDist) peaks.push(t);
-      }
-    }
-    return peaks;
-  }
-  const median = arr => { const s=[...arr].sort((a,b)=>a-b); const m=Math.floor(s.length/2); return s.length?(s.length%2?s[m]:(s[m-1]+s[m])/2):NaN; };
-  function rmssd(ibiSec){ if(ibiSec.length<3) return NaN; let sum=0,c=0; for(let i=1;i<ibiSec.length;i++){const d=(ibiSec[i]-ibiSec[i-1]); sum+=d*d; c++;} return Math.sqrt(sum/Math.max(c,1))*1000; }
-  function stressScore(rmssdMs){ if(!isFinite(rmssdMs)) return NaN; const cl=Math.max(15,Math.min(100,rmssdMs)); return Math.round(100-((cl-15)/(100-15))*100); }
-
-  function roiRect(){
-    const w=overlay.width, h=overlay.height;
-    const rw=w*0.45, rh=h*0.18, rx=(w-rw)/2, ry=h*0.22 - rh/2;
-    return {x:rx,y:ry,w:rw,h:rh};
-  }
-  function drawOverlay(){
-    const w=overlay.width,h=overlay.height; const ctx2=ctx;
-    ctx2.clearRect(0,0,w,h);
-    const r=roiRect();
-    ctx2.strokeStyle='rgba(96,165,250,.85)'; ctx2.lineWidth=2; ctx2.setLineDash([6,6]); ctx2.strokeRect(r.x,r.y,r.w,r.h); ctx2.setLineDash([]);
-    ctx2.fillStyle='rgba(20,20,20,.6)'; ctx2.fillRect(8,8,70,24);
-    ctx2.fillStyle='#e5e7eb'; ctx2.font='12px system-ui'; ctx2.fillText('LIVE',38,24);
-    ctx2.fillStyle='#f87171'; ctx2.beginPath(); ctx2.arc(20,20,6,0,Math.PI*2); ctx2.fill();
-  }
-
-  function pushSample(t, raw, filt, br){
-    times.push(t); rawVals.push(raw); filtVals.push(filt); breathVals.push(br);
-    const limit=t - MAX_SECONDS;
-    while(times.length && times[0] < limit){ times.shift(); rawVals.shift(); filtVals.shift(); breathVals.shift(); }
-  }
-
-  function computeMetrics(){
-    const now = times[times.length-1] || 0;
-
-    // Heart peaks
-    const pks = detectPeaks(filtVals, times, MIN_IBI);
-    const merged = [...peakTimes];
-    for(const p of pks) if(!merged.length || p - merged[merged.length-1] > 0.25) merged.push(p);
-    const keep = merged.filter(t => now - t <= 15);
-    peakTimes.length=0; peakTimes.push(...keep);
-    const ibis=[];
-    for(let i=1;i<peakTimes.length;i++){
-      const ibi = peakTimes[i] - peakTimes[i-1];
-      if(ibi>=MIN_IBI && ibi<=MAX_IBI) ibis.push(ibi);
-    }
-    const mIbi = median(ibis);
-    const hr = mIbi ? Math.round(60/mIbi) : NaN;
-
-    const hrvMs = rmssd(ibis);
-    const stress = stressScore(hrvMs);
-
-    // UI
-    hrEl.textContent = isFinite(hr) ? hr : '–';
-    if (isFinite(stress)){
-      stressEl.textContent = stress;
-      stressBadge.textContent = stress>=66?'Alto':(stress>=33?'Medio':'Bajo');
-      stressBadge.style.borderColor = stress>=66?'#f87171':(stress>=33?'#fbbf24':'#34d399');
-      stressBadge.style.color = stress>=66?'#fca5a5':(stress>=33?'#fde68a':'#86efac');
-    } else {
-      stressEl.textContent = '–'; stressBadge.textContent='—';
-      stressBadge.style.color = ''; stressBadge.style.borderColor = '';
-    }
-
-    // Pulse dot animation
-    if (isFinite(hr) && peakTimes.length){
-      const lastPeak = peakTimes[peakTimes.length-1];
-      const dt = (now - lastPeak) * (hr/60); // 1 around next beat
-      const scale = Math.max(0, 1 - dt);
-      pulseDot.style.boxShadow = `0 0 0 ${Math.round(scale*18)}px rgba(52,211,153,0.6)`;
-      pulseDot.style.background = '#34d399';
-    } else {
-      pulseDot.style.boxShadow = '0 0 0 0 rgba(52,211,153,0.6)';
-      pulseDot.style.background = '#334155';
-    }
-  }
-
-  function getRoiOnVideo(){
-    const vw = video.videoWidth, vh = video.videoHeight;
-    const ow = overlay.clientWidth, oh = overlay.clientHeight;
-    const r = roiRect();
-    return {
-      sx: Math.max(0, Math.floor(r.x * vw / ow)),
-      sy: Math.max(0, Math.floor(r.y * vh / oh)),
-      sw: Math.min(vw, Math.floor(r.w * vw / ow)),
-      sh: Math.min(vh, Math.floor(r.h * vh / oh))
-    };
-  }
-
-  function sampleLoop(){
-    if(!running) return;
-    const vw = video.videoWidth, vh = video.videoHeight;
-    if(!vw || !vh){ rafId = requestAnimationFrame(sampleLoop); return; }
-
-    const tmp = sampleLoop._tmp || (sampleLoop._tmp = document.createElement('canvas'));
-    tmp.width = vw; tmp.height = vh;
-    const tctx = tmp.getContext('2d', { willReadFrequently:true });
-    tctx.drawImage(video, 0, 0, vw, vh);
-
-    const {sx,sy,sw,sh} = getRoiOnVideo();
-    const frame = tctx.getImageData(sx,sy,sw,sh).data;
-
-    let sumG=0;
-    for(let i=0;i<frame.length;i+=4) sumG += frame[i+1];
-    const avgG = sumG / (frame.length/4);
-
-    const t = performance.now()/1000;
-    const dt = times.length ? (t - times[times.length-1]) : 1/30;
-
-    const filt = bandpass(avgG, dt, bpState);      // cardiac component
-    const br   = lowpass(avgG, dt, brState, 0.35); // slow component (not shown)
-
-    pushSample(t, avgG, filt, br);
-
-    if(!sampleLoop._acc || (t - sampleLoop._acc) > 0.3){
-      computeMetrics();
-      drawOverlay();
-      sampleLoop._acc = t;
-    }
-    rafId = requestAnimationFrame(sampleLoop);
-  }
-
-  function resetBuffers(){
-    times.length=rawVals.length=filtVals.length=breathVals.length=peakTimes.length=0;
-    bpState.hp=bpState.lp=bpState.prev=0; brState.lp=0;
-  }
-
-  async function startMeasurement(){
-    // iOS needs a user gesture: this is triggered by button clicks
-    statusEl.textContent = 'Solicitando cámara…';
-    try {
-      // pre-permission trick to list devices
-      await navigator.mediaDevices.getUserMedia({ video: true, audio: false })
-        .then(s => s.getTracks().forEach(t => t.stop()))
-        .catch(()=>{});
-      await listCameras();
-      await startCamera();
-      resetBuffers();
-      running = true; sampleLoop();
-      btnStart.disabled = true;
-      btnStop.disabled = false;
-      statusEl.textContent = 'Calibrando… mantén la cara estable (10–20 s).';
-    } catch (e){
-      alert('No se pudo acceder a la cámara. Usa HTTPS o localhost y permite el acceso.');
-      statusEl.textContent = 'Error: sin cámara.';
-      btnStart.disabled = false;
-    }
-  }
-
-  function stopMeasurement(){
-    running = false; cancelAnimationFrame(rafId);
-    stopCamera();
-    btnStart.disabled = false;
-    btnStop.disabled = true;
-    statusEl.textContent = '';
-    hrEl.textContent = '–'; stressEl.textContent = '–'; stressBadge.textContent = '—';
-    pulseDot.style.boxShadow = '0 0 0 0 rgba(52,211,153,0.6)';
-  }
-
-  btnStart?.addEventListener('click', startMeasurement);
-  btnStop?.addEventListener('click', stopMeasurement);
-
-  // Close modal on ESC or background click
-  document.addEventListener('keydown', (e)=>{
-    if (e.key === 'Escape' && modal.classList.contains('show')) closeDemo();
-  });
-  modal.addEventListener('click', (e)=>{
-    if (e.target === modal) closeDemo();
-  });
-})();
+window.addEventListener('pagehide', () => {
+  demoController.stop();
+});

--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OpenVitals Live Demo</title>
+  <meta name="description" content="Try the OpenVitals camera-based vital sign monitor directly in your browser." />
+  <link rel="manifest" href="manifest.webmanifest" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body class="demo-page">
+  <header class="demo-header">
+    <div class="demo-brand">
+      <span class="demo-name">OpenVitals Monitor</span>
+      <span class="demo-sub">Live camera demo</span>
+    </div>
+    <a class="ghost" href="index.html">← Back to overview</a>
+  </header>
+
+  <main>
+    <section class="demo-intro">
+      <h1>Run the camera vitals capture</h1>
+      <p>Allow camera access, align your forehead with the overlay and remain still for 20 seconds while the signal stabilises. Metrics update continuously once a clean pulse is detected.</p>
+      <ul>
+        <li>Works best in bright, even front lighting.</li>
+        <li>Keep your head centred and reduce movement.</li>
+        <li>Use Chrome, Edge or Safari over HTTPS or localhost.</li>
+      </ul>
+    </section>
+
+    <section class="demo-panel">
+      <div class="demo-layout">
+        <div class="video-col">
+          <div class="video-wrap">
+            <video id="video" autoplay playsinline webkit-playsinline muted></video>
+            <canvas id="overlay"></canvas>
+            <div id="roi" class="roi">Align your forehead here</div>
+          </div>
+          <div class="controls">
+            <div class="row">
+              <label for="cameraSelect">Camera</label>
+              <select id="cameraSelect"></select>
+              <button id="btnStart" class="primary">Start</button>
+              <button id="btnStop" class="ghost" disabled>Stop</button>
+            </div>
+            <div class="row note">
+              <small>Video never leaves the browser. Permissions are only used locally.</small>
+            </div>
+          </div>
+        </div>
+
+        <div class="metrics-col">
+          <div class="kpis">
+            <div class="kpi">
+              <div class="label">Heart rate</div>
+              <div class="value"><span id="hrVal">–</span><span class="unit">bpm</span></div>
+              <div class="pulse" id="pulseDot"></div>
+            </div>
+            <div class="kpi">
+              <div class="label">Stress index</div>
+              <div class="value"><span id="stressVal">–</span><span class="unit">/100</span></div>
+              <div id="stressBadge" class="badge">—</div>
+            </div>
+            <div class="kpi">
+              <div class="label">RMSSD</div>
+              <div class="value"><span id="hrvVal">–</span><span class="unit">ms</span></div>
+            </div>
+            <div class="kpi">
+              <div class="label">Respiration</div>
+              <div class="value"><span id="rrVal">–</span><span class="unit">rpm</span></div>
+            </div>
+          </div>
+
+          <div class="actions">
+            <span id="status" class="muted"></span>
+            <span id="quality" class="badge subtle">Signal quality: —</span>
+          </div>
+
+          <p class="demo-disclaimer">For wellness and research use only. This experience is not a medical device.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="demo-footer">
+    <small>&copy; OpenVitals demo. Built for educational purposes.</small>
+  </footer>
+
+  <script type="module" src="demo.js"></script>
+</body>
+</html>

--- a/demo.js
+++ b/demo.js
@@ -1,0 +1,37 @@
+import { VitalsDemo } from './vitals-demo.js';
+
+const video = document.getElementById('video');
+const overlay = document.getElementById('overlay');
+const btnStart = document.getElementById('btnStart');
+const btnStop = document.getElementById('btnStop');
+const cameraSelect = document.getElementById('cameraSelect');
+const hrEl = document.getElementById('hrVal');
+const stressEl = document.getElementById('stressVal');
+const stressBadge = document.getElementById('stressBadge');
+const hrvEl = document.getElementById('hrvVal');
+const rrEl = document.getElementById('rrVal');
+const statusEl = document.getElementById('status');
+const qualityEl = document.getElementById('quality');
+const pulseDot = document.getElementById('pulseDot');
+
+const demoController = new VitalsDemo({
+  videoElement: video,
+  overlayCanvas: overlay,
+  startButton: btnStart,
+  stopButton: btnStop,
+  cameraSelect,
+  hrEl,
+  stressEl,
+  stressBadge,
+  hrvEl,
+  rrEl,
+  statusEl,
+  qualityEl,
+  pulseDot,
+});
+
+demoController.refreshCameras();
+
+window.addEventListener('pagehide', () => {
+  demoController.stop();
+});

--- a/index.html
+++ b/index.html
@@ -1,140 +1,128 @@
 <!doctype html>
-<html lang="es">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Vitals Live — Demo de Venta</title>
-  <meta name="description" content="Demo de venta: signos vitales en tiempo real con la cámara. Producto para bienestar (no médico)." />
+  <title>OpenVitals Monitor</title>
+  <meta name="description" content="Camera-based vital sign monitor with an embeddable SDK for heart rate, stress and breathing estimation." />
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml">
   <link rel="stylesheet" href="styles.css" />
-  <script defer src="app.js"></script>
 </head>
 <body>
-  <header class="topbar">
-    <div class="brand">
-      <img src="assets/logo.svg" alt="Logo" class="logo"/>
-      <span>Vitals Live</span>
+  <header class="site-header">
+    <div class="site-brand">
+      <span class="site-name">OpenVitals Monitor</span>
+      <span class="site-tagline">Camera-based vital sign capture</span>
     </div>
-    <nav class="nav">
-      <a href="presentation.html" class="link">Presentación</a>
-      <a href="#casos" class="link">Casos de uso</a>
-      <a href="#precios" class="link">Precios</a>
-      <button id="btnOpenDemo" class="primary">Demo en vivo</button>
+    <nav class="site-nav">
+      <a class="nav-link" href="#overview">Overview</a>
+      <a class="nav-link" href="#sdk">SDK</a>
+      <a class="nav-link" href="demo.html">Live demo</a>
+      <button id="btnOpenDemo" class="primary">Launch live capture</button>
     </nav>
   </header>
 
   <main>
-    <section class="hero">
-      <h1>Signos vitales <span class="grad">en tiempo real</span> usando tu cámara</h1>
-      <p class="sub">Muestra el “wow” en segundos. Sin wearables, sin cables, directamente desde el navegador. <strong>Uso de bienestar (no médico).</strong></p>
+    <section id="overview" class="hero">
+      <h1>Measure health signals with nothing but a camera</h1>
+      <p class="lead">OpenVitals Monitor extracts pulse, variability and breathing trends directly from the forehead using remote photoplethysmography (rPPG). All processing runs on device &mdash; no branding, no data leaves the browser.</p>
       <div class="cta">
-        <button id="btnOpenDemo2" class="primary xl">Iniciar demo en vivo</button>
-        <a class="ghost xl" href="presentation.html">Ver presentación</a>
+        <button id="btnOpenDemo2" class="primary xl">Start live scan</button>
+        <a class="ghost xl" href="demo.html">Open full demo</a>
+        <a class="ghost xl" href="#sdk">Read the SDK guide</a>
       </div>
-      <ul class="bullets">
-        <li>Funciona en iPhone y Android (HTTPS/localhost)</li>
-        <li>Datos procesados en el dispositivo</li>
-        <li>Enseña el producto sin revelar todo el producto</li>
+      <ul class="highlight-grid">
+        <li>Works on modern desktop and mobile browsers</li>
+        <li>No wearables or external sensors required</li>
+        <li>Includes a reusable JavaScript SDK</li>
+        <li>Well suited for wellness, research and prototyping</li>
       </ul>
     </section>
 
-    <section class="features">
-      <div class="feature">
-        <h3>Medición instantánea</h3>
-        <p>Extrae pulso y nivel de estrés estimado desde microcambios de color (rPPG).</p>
+    <section class="feature-grid">
+      <article>
+        <h3>Heart rate</h3>
+        <p>Band-pass filtering isolates cardiac pulses from subtle color changes in the forehead region. Peak timing is used to derive beats per minute.</p>
+      </article>
+      <article>
+        <h3>Stress index</h3>
+        <p>We estimate a stress score from the short-term heart rate variability (RMSSD). Higher variability tends to correlate with lower stress.</p>
+      </article>
+      <article>
+        <h3>Breathing trend</h3>
+        <p>A low-pass channel tracks slower oscillations to approximate respiratory rate. This provides a calming-breathing guide without extra hardware.</p>
+      </article>
+      <article>
+        <h3>Signal quality</h3>
+        <p>Real-time quality indicators help you instruct users: sit still, face the camera and stay in good lighting to obtain stable signals.</p>
+      </article>
+    </section>
+
+    <section class="how-it-works">
+      <div>
+        <h2>How it works</h2>
+        <ol>
+          <li>We crop a region of interest on the forehead and average its green channel intensity frame by frame.</li>
+          <li>Digital filters separate cardiac and respiratory components, then peaks are detected to estimate timing.</li>
+          <li>Metrics are derived from peak intervals and published through the SDK so you can build your own experience.</li>
+        </ol>
       </div>
-      <div class="feature">
-        <h3>Privacidad por diseño</h3>
-        <p> Procesamiento en el dispositivo. No subimos el video al servidor.</p>
-      </div>
-      <div class="feature">
-        <h3>Presentación comercial</h3>
-        <p>Incluye un pitch listo para inversores y clientes, y un demo controlado.</p>
-      </div>
-      <div class="feature">
-        <h3>Escalable</h3>
-        <p>Extensible a métricas “Pro” (RR, HRV, presión estimada, etc.).</p>
+      <div class="callout">
+        <strong>Privacy first.</strong> Everything runs locally inside the user browser. Streams never leave the device.
       </div>
     </section>
 
-    <section id="casos" class="cases">
-      <h2>Casos de uso</h2>
-      <div class="cards">
-        <div class="card">
-          <h4>Wellness & Fitness</h4>
-          <p>Checks rápidos antes/después de entrenar. Respiración guiada.</p>
-        </div>
-        <div class="card">
-          <h4>Telebienestar</h4>
-          <p>Seguimiento no invasivo en sesiones remotas.</p>
-        </div>
-        <div class="card">
-          <h4>Empresas</h4>
-          <p>Programas de bienestar: estrés y recuperación.</p>
-        </div>
-        <div class="card">
-          <h4>Investigación UX</h4>
-          <p>Métricas fisiológicas para test A/B en laboratorio.</p>
-        </div>
-      </div>
-    </section>
+    <section id="sdk" class="sdk-section">
+      <h2>SDK quick start</h2>
+      <p>Import the <code>CameraVitalsSDK</code> module to embed live rPPG capture into any web application.</p>
+<pre><code>import { CameraVitalsSDK } from './sdk.js';
 
-    <section id="precios" class="pricing">
-      <h2>Precios</h2>
-      <div class="tiers">
-        <div class="tier">
-          <div class="badge">Demo</div>
-          <h3>Gratis</h3>
-          <ul>
-            <li>Pulso (BPM)</li>
-            <li>Estrés estimado</li>
-            <li>Sin instalación (web)</li>
-          </ul>
-          <button class="primary" id="btnOpenDemo3">Probar ahora</button>
-        </div>
-        <div class="tier">
-          <div class="badge pro">Pro</div>
-          <h3>A medida</h3>
-          <ul>
-            <li>Respiración (RPM) <span class="lock">Bloqueado</span></li>
-            <li>HRV (RMSSD) <span class="lock">Bloqueado</span></li>
-            <li>SDK e integración</li>
-            <li>Soporte y SLAs</li>
-          </ul>
-          <a class="ghost" href="presentation.html">Solicitar propuesta</a>
-        </div>
-      </div>
-      <p class="disclaimer">Esta demo es para bienestar. No brinda diagnóstico clínico ni sustituye dispositivos médicos.</p>
+const sdk = new CameraVitalsSDK({
+  videoElement: document.querySelector('#video'),
+  overlayCanvas: document.querySelector('#overlay')
+});
+
+const cameras = await sdk.listCameras({ requestAccess: true });
+await sdk.start({ deviceId: cameras[0]?.deviceId });
+
+sdk.addEventListener('metrics', (event) => {
+  const { heartRate, stressScore, hrvMs, breathingRate } = event.detail;
+  console.log('Live metrics', heartRate, stressScore, hrvMs, breathingRate);
+});
+</code></pre>
+      <p>The SDK exposes helpers to list cameras, start/stop capture, and receive metric, status and error events. See the README for a full API reference.</p>
     </section>
   </main>
 
-  <footer class="footer">
-    <small>© 2025 Vitals Live · Demo de venta · Uso no médico</small>
+  <footer class="site-footer">
+    <small>For wellness and research use only. This is not a medical device and it does not provide diagnoses.</small>
   </footer>
 
-  <!-- Demo Modal -->
   <div id="demoModal" class="modal" aria-hidden="true">
     <div class="modal-dialog" role="dialog" aria-modal="true" aria-labelledby="demoTitle">
-      <button id="btnCloseDemo" class="close" aria-label="Cerrar">✕</button>
+      <button id="btnCloseDemo" class="close" aria-label="Close">✕</button>
+      <header class="modal-header">
+        <h2 id="demoTitle">Live vitals capture</h2>
+        <p>Keep still, face the camera and use even front lighting for 15&ndash;20 seconds while the signal stabilises.</p>
+      </header>
       <div class="demo-layout">
         <div class="video-col">
           <div class="video-wrap">
             <video id="video" autoplay playsinline webkit-playsinline muted></video>
             <canvas id="overlay"></canvas>
-            <div id="roi" class="roi">Alinea tu frente aquí</div>
+            <div id="roi" class="roi">Align your forehead here</div>
           </div>
           <div class="controls">
             <div class="row">
-              <label for="cameraSelect">Cámara:</label>
+              <label for="cameraSelect">Camera</label>
               <select id="cameraSelect"></select>
-              <button id="btnStart" class="primary">Iniciar</button>
-              <button id="btnStop" class="ghost" disabled>Detener</button>
+              <button id="btnStart" class="primary">Start</button>
+              <button id="btnStop" class="ghost" disabled>Stop</button>
             </div>
             <div class="row note">
-              <small>Usa luz frontal, evita moverte. Safari/Chrome móvil: requiere HTTPS o localhost.</small>
+              <small>Supported in Chrome, Edge, Safari (HTTPS or localhost required).</small>
             </div>
           </div>
         </div>
@@ -142,46 +130,41 @@
         <div class="metrics-col">
           <div class="kpis">
             <div class="kpi">
-              <div class="label">Pulso</div>
+              <div class="label">Heart rate</div>
               <div class="value"><span id="hrVal">–</span><span class="unit">bpm</span></div>
               <div class="pulse" id="pulseDot"></div>
             </div>
             <div class="kpi">
-              <div class="label">Estrés</div>
+              <div class="label">Stress index</div>
               <div class="value"><span id="stressVal">–</span><span class="unit">/100</span></div>
               <div id="stressBadge" class="badge">—</div>
             </div>
-          </div>
-
-          <div class="pro-grid">
-            <div class="pro-card locked">
-              <div class="lock-text">Pro</div>
-              <div class="label">Respiración</div>
-              <div class="value">— <span class="unit">rpm</span></div>
+            <div class="kpi">
+              <div class="label">RMSSD</div>
+              <div class="value"><span id="hrvVal">–</span><span class="unit">ms</span></div>
             </div>
-            <div class="pro-card locked">
-              <div class="lock-text">Pro</div>
-              <div class="label">HRV (RMSSD)</div>
-              <div class="value">— <span class="unit">ms</span></div>
+            <div class="kpi">
+              <div class="label">Respiration</div>
+              <div class="value"><span id="rrVal">–</span><span class="unit">rpm</span></div>
             </div>
           </div>
 
           <div class="actions">
-            <a href="presentation.html" class="primary">Ver propuesta</a>
             <span id="status" class="muted"></span>
+            <span id="quality" class="badge subtle">Signal quality: —</span>
           </div>
 
-          <p class="demo-disclaimer">Procesamiento en tu dispositivo. No subimos el video.</p>
+          <p class="demo-disclaimer">All processing happens locally. No video data is transmitted.</p>
         </div>
       </div>
     </div>
   </div>
 
+  <script type="module" src="app.js"></script>
   <script>
-    // PWA: registra service worker si disponible
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {
-        navigator.serviceWorker.register('sw.js').catch(()=>{});
+        navigator.serviceWorker.register('sw.js').catch(() => {});
       });
     }
   </script>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,9 +1,9 @@
 {
-  "name": "Vitals Live Demo",
-  "short_name": "Vitals",
+  "name": "OpenVitals Monitor",
+  "short_name": "OpenVitals",
   "start_url": ".",
   "display": "standalone",
-  "background_color": "#0f172a",
-  "theme_color": "#0f172a",
+  "background_color": "#0b1220",
+  "theme_color": "#0b1220",
   "icons": []
 }

--- a/presentation.html
+++ b/presentation.html
@@ -1,116 +1,95 @@
 <!doctype html>
-<html lang="es">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Presentación — Vitals Live</title>
+  <title>OpenVitals Monitor — Overview</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body class="slide-shell">
   <div class="slide-nav">
-    <div style="display:flex;align-items:center;gap:10px">
-      <img src="assets/logo.svg" alt="Logo" class="logo"/>
-      <strong>Vitals Live — Presentación</strong>
-    </div>
+    <strong>OpenVitals Monitor</strong>
     <div class="btns">
-      <a class="btn" href="index.html">Home</a>
-      <a class="btn primary" href="index.html">Abrir demo</a>
+      <a class="btn" href="index.html">Overview</a>
+      <a class="btn primary" href="index.html#sdk">View SDK</a>
     </div>
   </div>
 
   <section class="slide show" data-i="0">
     <div class="content">
-      <h1>Signos vitales desde la cámara</h1>
-      <p>Monitoreo no invasivo, en tiempo real, para bienestar y rendimiento. Sin wearables.</p>
+      <h1>Camera-based vitals in the browser</h1>
+      <p>Remote photoplethysmography (rPPG) lets you extract heart rate, stress and breathing trends with nothing more than a standard camera.</p>
     </div>
   </section>
 
   <section class="slide" data-i="1">
     <div class="content">
-      <h2>Problema</h2>
-      <p>Las empresas y apps de salud necesitan señales fisiológicas rápidas y sin fricción. Los wearables tienen costos, logística y adopción limitada.</p>
+      <h2>Why it matters</h2>
+      <p>Wellness apps, research teams and telehealth pilots need quick physiological signal capture without wearables or complex logistics.</p>
     </div>
   </section>
 
   <section class="slide" data-i="2">
     <div class="content">
-      <h2>Solución</h2>
-      <p>rPPG (fotopletismografía remota): detectamos microcambios de color en la piel para estimar pulso y estrés — usando solo la cámara.</p>
+      <h2>Signal pipeline</h2>
+      <p>We focus on the forehead, average the green channel, apply digital filters and detect peaks to estimate heartbeat timing and variability.</p>
     </div>
   </section>
 
   <section class="slide" data-i="3">
     <div class="content">
-      <h2>Cómo funciona</h2>
-      <p>El algoritmo extrae una señal óptica de la frente/mejillas, la filtra en banda cardíaca y detecta latidos. Desde la variabilidad, estimamos el estrés.</p>
+      <h2>Metrics available</h2>
+      <p>Heart rate (BPM), RMSSD, stress index and respiratory trend are streamed via the SDK so you can design your own UI and workflows.</p>
     </div>
   </section>
 
   <section class="slide" data-i="4">
     <div class="content">
-      <h2>Demo controlada</h2>
-      <p>Mostramos <strong>Pulso</strong> y <strong>Estrés</strong>. Métricas “Pro” (RR, HRV avanzado, riesgo cardiovascular) quedan bloqueadas en esta demo.</p>
+      <h2>What you need</h2>
+      <p>A modern browser with camera access, even lighting and a cooperative subject. All processing stays on-device for privacy.</p>
     </div>
   </section>
 
   <section class="slide" data-i="5">
     <div class="content">
-      <h2>Mercados</h2>
-      <p>Wellness B2C, programas de bienestar corporativo, telerehabilitación no clínica, investigación UX, deportes.</p>
-    </div>
-  </section>
-
-  <section class="slide" data-i="6">
-    <div class="content">
-      <h2>Modelo de negocio</h2>
-      <p>Licencia SDK + API Pro (por MAU o por dispositivo), marca blanca, y proyectos a medida con SLAs.</p>
-    </div>
-  </section>
-
-  <section class="slide" data-i="7">
-    <div class="content">
-      <h2>Roadmap</h2>
-      <p>Detección facial automática, calidad de señal (SNR), respiración guiada, dashboards, integraciones (Apple/Google Health).</p>
-    </div>
-  </section>
-
-  <section class="slide" data-i="8">
-    <div class="content">
-      <h2>CTA</h2>
-      <p>¿Te interesa? Probemos un piloto. <a href="index.html">Abrir demo</a></p>
+      <h2>Next steps</h2>
+      <p>Integrate the SDK, monitor metrics via the `metrics` event and build custom experiences around capture quality and guidance.</p>
     </div>
   </section>
 
   <div class="dotbar" id="dotbar"></div>
 
   <script>
-    // Simple slide controller
     const slides = Array.from(document.querySelectorAll('.slide'));
     const dotbar = document.getElementById('dotbar');
 
-    function renderDots(i){
+    function renderDots(active) {
       dotbar.innerHTML = '';
-      slides.forEach((_, idx)=>{
-        const d=document.createElement('div'); d.className='dot'+(idx===i?' active':'');
-        dotbar.appendChild(d);
+      slides.forEach((_, idx) => {
+        const dot = document.createElement('div');
+        dot.className = 'dot' + (idx === active ? ' active' : '');
+        dotbar.appendChild(dot);
       });
     }
 
-    let i = 0; renderDots(i);
-    function show(n){
-      i = (n+slides.length)%slides.length;
-      slides.forEach((s,idx)=> s.classList.toggle('show', idx===i));
-      renderDots(i);
+    let index = 0;
+    renderDots(index);
+
+    function show(i) {
+      index = (i + slides.length) % slides.length;
+      slides.forEach((slide, idx) => slide.classList.toggle('show', idx === index));
+      renderDots(index);
     }
-    document.addEventListener('keydown', (e)=>{
-      if (e.key==='ArrowRight' || e.key==='PageDown') show(i+1);
-      if (e.key==='ArrowLeft'  || e.key==='PageUp') show(i-1);
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'ArrowRight' || event.key === 'PageDown') show(index + 1);
+      if (event.key === 'ArrowLeft' || event.key === 'PageUp') show(index - 1);
     });
-    document.addEventListener('click', (e)=>{
-      if (e.target.classList.contains('dot')){
-        const idx = Array.from(dotbar.children).indexOf(e.target);
-        if (idx>=0) show(idx);
-      }
+
+    dotbar.addEventListener('click', (event) => {
+      if (!event.target.classList.contains('dot')) return;
+      const idx = Array.from(dotbar.children).indexOf(event.target);
+      if (idx >= 0) show(idx);
     });
   </script>
 </body>

--- a/sdk.js
+++ b/sdk.js
@@ -1,0 +1,414 @@
+export class CameraVitalsSDK extends EventTarget {
+  constructor({ videoElement, overlayCanvas } = {}) {
+    super();
+    if (!videoElement) {
+      throw new Error('videoElement is required');
+    }
+    this.video = videoElement;
+    this.overlay = overlayCanvas || null;
+    this.ctx = this.overlay ? this.overlay.getContext('2d') : null;
+
+    this.stream = null;
+    this.track = null;
+    this.running = false;
+    this.rafId = null;
+
+    this._times = [];
+    this._rawVals = [];
+    this._filtVals = [];
+    this._breathVals = [];
+    this._peakTimes = [];
+
+    this._bpState = { hp: 0, lp: 0, prev: 0 };
+    this._brState = { lp: 0 };
+
+    this._onResize = () => this._fitCanvas();
+  }
+
+  async listCameras({ requestAccess = false } = {}) {
+    if (!navigator.mediaDevices?.enumerateDevices) {
+      throw new Error('Camera enumeration is not supported in this browser');
+    }
+
+    if (requestAccess) {
+      try {
+        const tmp = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+        tmp.getTracks().forEach((track) => track.stop());
+      } catch (err) {
+        this._dispatchError('camera-permission', err);
+        throw err;
+      }
+    }
+
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const cameras = devices.filter((d) => d.kind === 'videoinput');
+    this.dispatchEvent(new CustomEvent('cameralist', { detail: cameras }));
+    return cameras;
+  }
+
+  async start({ deviceId } = {}) {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      throw new Error('getUserMedia is not supported in this browser');
+    }
+
+    await this.stop();
+    this._dispatchStatus('Requesting camera access…');
+
+    try {
+      const facingMode = deviceId ? undefined : 'user';
+      this.stream = await navigator.mediaDevices.getUserMedia({
+        audio: false,
+        video: {
+          width: { ideal: 1280 },
+          height: { ideal: 720 },
+          frameRate: { ideal: 30, max: 60 },
+          deviceId: deviceId ? { exact: deviceId } : undefined,
+          facingMode,
+        },
+      });
+      this.video.srcObject = this.stream;
+      this.track = this.stream.getVideoTracks()[0] || null;
+      await this.video.play();
+
+      if (this.overlay) {
+        this._fitCanvas();
+        window.addEventListener('resize', this._onResize);
+      }
+
+      this._mirrorVideoIfNeeded();
+      this._resetBuffers();
+      this.running = true;
+      this._dispatchStatus('Calibrating… hold still.');
+      this._sampleLoop();
+    } catch (err) {
+      this._dispatchError('camera-start', err);
+      this._dispatchStatus('Camera error. Allow permissions and use HTTPS.');
+      throw err;
+    }
+  }
+
+  async stop() {
+    this.running = false;
+    if (this.rafId) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
+    if (this.stream) {
+      this.stream.getTracks().forEach((t) => t.stop());
+    }
+    this.stream = null;
+    this.track = null;
+
+    if (this.overlay) {
+      window.removeEventListener('resize', this._onResize);
+      this._clearOverlay();
+    }
+
+    if (this.video) {
+      this.video.srcObject = null;
+    }
+
+    this._resetBuffers();
+    this._dispatchStatus('Stopped.');
+  }
+
+  /* Internal helpers */
+  _fitCanvas() {
+    if (!this.overlay) return;
+    this.overlay.width = this.video?.clientWidth || this.overlay.width;
+    this.overlay.height = this.video?.clientHeight || this.overlay.height;
+  }
+
+  _clearOverlay() {
+    if (!this.ctx) return;
+    this.ctx.clearRect(0, 0, this.overlay.width, this.overlay.height);
+  }
+
+  _mirrorVideoIfNeeded() {
+    if (!this.track) return;
+    try {
+      const settings = this.track.getSettings?.() || {};
+      const isFront = settings.facingMode === 'user' || settings.facingMode === 'front';
+      this.video.style.transform = isFront ? 'scaleX(-1)' : 'none';
+    } catch (err) {
+      console.warn('Cannot read facing mode', err);
+    }
+  }
+
+  _sampleLoop() {
+    if (!this.running) return;
+    const vw = this.video.videoWidth;
+    const vh = this.video.videoHeight;
+
+    if (!vw || !vh) {
+      this.rafId = requestAnimationFrame(() => this._sampleLoop());
+      return;
+    }
+
+    if (!this._scratch) {
+      this._scratch = document.createElement('canvas');
+      this._scratchCtx = this._scratch.getContext('2d', { willReadFrequently: true });
+    }
+    this._scratch.width = vw;
+    this._scratch.height = vh;
+
+    this._scratchCtx.drawImage(this.video, 0, 0, vw, vh);
+    const { sx, sy, sw, sh } = this._roiOnVideo();
+    const frame = this._scratchCtx.getImageData(sx, sy, sw, sh).data;
+
+    let sum = 0;
+    for (let i = 0; i < frame.length; i += 4) {
+      sum += frame[i + 1];
+    }
+    const avgGreen = sum / (frame.length / 4 || 1);
+
+    const now = performance.now() / 1000;
+    const dt = this._times.length ? now - this._times[this._times.length - 1] : 1 / 30;
+
+    const cardiac = this._bandpass(avgGreen, dt, this._bpState);
+    const breath = this._lowpass(avgGreen, dt, this._brState, 0.33);
+
+    this._pushSample(now, avgGreen, cardiac, breath);
+
+    if (!this._lastOverlay || now - this._lastOverlay > 0.25) {
+      this._drawOverlay();
+      this._lastOverlay = now;
+    }
+
+    if (!this._lastMetrics || now - this._lastMetrics > 0.3) {
+      const metrics = this._computeMetrics();
+      this.dispatchEvent(new CustomEvent('metrics', { detail: metrics }));
+      this._lastMetrics = now;
+    }
+
+    this.rafId = requestAnimationFrame(() => this._sampleLoop());
+  }
+
+  _roiRect() {
+    if (!this.overlay) {
+      return { x: 0.27, y: 0.2, w: 0.46, h: 0.18 };
+    }
+    const w = this.overlay.width;
+    const h = this.overlay.height;
+    const rw = w * 0.46;
+    const rh = h * 0.18;
+    const rx = (w - rw) / 2;
+    const ry = h * 0.22 - rh / 2;
+    return { x: rx, y: ry, w: rw, h: rh };
+  }
+
+  _roiOnVideo() {
+    const vw = this.video.videoWidth;
+    const vh = this.video.videoHeight;
+    const ow = this.overlay?.clientWidth || this.video.clientWidth || vw;
+    const oh = this.overlay?.clientHeight || this.video.clientHeight || vh;
+    const r = this._roiRect();
+    return {
+      sx: Math.max(0, Math.floor(r.x * vw / ow)),
+      sy: Math.max(0, Math.floor(r.y * vh / oh)),
+      sw: Math.max(1, Math.floor(r.w * vw / ow)),
+      sh: Math.max(1, Math.floor(r.h * vh / oh)),
+    };
+  }
+
+  _drawOverlay() {
+    if (!this.ctx || !this.overlay) return;
+    const w = this.overlay.width;
+    const h = this.overlay.height;
+    this.ctx.clearRect(0, 0, w, h);
+
+    const r = this._roiRect();
+    this.ctx.save();
+    this.ctx.strokeStyle = 'rgba(96,165,250,0.85)';
+    this.ctx.lineWidth = 2;
+    this.ctx.setLineDash([6, 6]);
+    this.ctx.strokeRect(r.x, r.y, r.w, r.h);
+    this.ctx.restore();
+
+    this.ctx.fillStyle = 'rgba(20,27,45,0.75)';
+    this.ctx.fillRect(12, 12, 72, 26);
+    this.ctx.fillStyle = '#60a5fa';
+    this.ctx.font = '12px system-ui';
+    this.ctx.fillText('LIVE', 40, 28);
+    this.ctx.beginPath();
+    this.ctx.fillStyle = '#34d399';
+    this.ctx.arc(24, 25, 6, 0, Math.PI * 2);
+    this.ctx.fill();
+  }
+
+  _pushSample(time, raw, filtered, breath) {
+    const MAX_SECONDS = 25;
+    this._times.push(time);
+    this._rawVals.push(raw);
+    this._filtVals.push(filtered);
+    this._breathVals.push(breath);
+
+    const limit = time - MAX_SECONDS;
+    while (this._times.length && this._times[0] < limit) {
+      this._times.shift();
+      this._rawVals.shift();
+      this._filtVals.shift();
+      this._breathVals.shift();
+    }
+  }
+
+  _resetBuffers() {
+    this._times.length = 0;
+    this._rawVals.length = 0;
+    this._filtVals.length = 0;
+    this._breathVals.length = 0;
+    this._peakTimes.length = 0;
+    this._bpState.hp = this._bpState.lp = this._bpState.prev = 0;
+    this._brState.lp = 0;
+  }
+
+  _bandpass(value, dt, state) {
+    const fcHP = 0.7;
+    const rcHP = 1 / (2 * Math.PI * fcHP);
+    const aHP = rcHP / (rcHP + dt);
+    state.hp = aHP * (state.hp + value - state.prev);
+    state.prev = value;
+
+    const fcLP = 3.0;
+    const rcLP = 1 / (2 * Math.PI * fcLP);
+    const aLP = dt / (rcLP + dt);
+    state.lp = state.lp + aLP * (state.hp - state.lp);
+    return state.lp;
+  }
+
+  _lowpass(value, dt, state, fc = 0.35) {
+    const rc = 1 / (2 * Math.PI * fc);
+    const a = dt / (rc + dt);
+    state.lp = state.lp + a * (value - state.lp);
+    return state.lp;
+  }
+
+  _computeMetrics() {
+    const now = this._times[this._times.length - 1] || 0;
+
+    const peaks = this._detectPeaks(this._filtVals, this._times, 0.33);
+    const merged = [...this._peakTimes];
+    for (const peak of peaks) {
+      if (!merged.length || peak - merged[merged.length - 1] > 0.25) {
+        merged.push(peak);
+      }
+    }
+    const keep = merged.filter((t) => now - t <= 18);
+    this._peakTimes.length = 0;
+    this._peakTimes.push(...keep);
+
+    const ibis = [];
+    for (let i = 1; i < this._peakTimes.length; i++) {
+      const interval = this._peakTimes[i] - this._peakTimes[i - 1];
+      if (interval >= 0.33 && interval <= 1.6) {
+        ibis.push(interval);
+      }
+    }
+
+    const medianIbi = this._median(ibis);
+    const heartRate = medianIbi ? Math.round(60 / medianIbi) : NaN;
+
+    const hrvMs = this._rmssd(ibis);
+    const stressScore = this._stressFromRmssd(hrvMs);
+
+    const breathingRate = this._estimateBreathing();
+
+    const signalStrength = this._signalQuality();
+
+    const lastBeat = this._peakTimes.length ? this._peakTimes[this._peakTimes.length - 1] : null;
+    const beatPhase = lastBeat ? (now - lastBeat) * (heartRate ? heartRate / 60 : 0) : null;
+
+    if (Number.isFinite(heartRate) && this._peakTimes.length >= 4) {
+      this._dispatchStatus('Capturing in real time.');
+    }
+
+    return {
+      timestamp: now,
+      heartRate: Number.isFinite(heartRate) ? heartRate : null,
+      stressScore: Number.isFinite(stressScore) ? stressScore : null,
+      hrvMs: Number.isFinite(hrvMs) ? Math.round(hrvMs) : null,
+      breathingRate: Number.isFinite(breathingRate) ? Math.round(breathingRate) : null,
+      beatPhase,
+      signalQuality: signalStrength,
+      samplesCollected: this._times.length,
+    };
+  }
+
+  _estimateBreathing() {
+    if (this._breathVals.length < 30) return NaN;
+    const breathPeaks = this._detectPeaks(this._breathVals, this._times, 1.6, 0.2);
+    if (breathPeaks.length < 2) return NaN;
+    const intervals = [];
+    for (let i = 1; i < breathPeaks.length; i++) {
+      const interval = breathPeaks[i] - breathPeaks[i - 1];
+      if (interval > 1 && interval < 10) intervals.push(interval);
+    }
+    const medianBreath = this._median(intervals);
+    return medianBreath ? 60 / medianBreath : NaN;
+  }
+
+  _signalQuality() {
+    if (this._filtVals.length < 30) return 0;
+    const slice = this._filtVals.slice(-120);
+    const mean = slice.reduce((a, b) => a + b, 0) / slice.length;
+    const variance = slice.reduce((acc, val) => acc + Math.pow(val - mean, 2), 0) / slice.length;
+    const std = Math.sqrt(Math.max(variance, 0));
+    const normalized = Math.max(0, Math.min(1, std / 20));
+    return Math.round(normalized * 100) / 100;
+  }
+
+  _detectPeaks(series, timeSeries, minDistance, thresholdScale = 0.5) {
+    const n = series.length;
+    if (n < 5) return [];
+    const mean = series.reduce((a, b) => a + b, 0) / n;
+    const sd = Math.sqrt(series.reduce((acc, val) => acc + Math.pow(val - mean, 2), 0) / n) || 1;
+    const threshold = mean + thresholdScale * sd;
+    const peaks = [];
+    for (let i = 2; i < n - 2; i++) {
+      const v = series[i];
+      if (v > threshold && v > series[i - 1] && v > series[i + 1] && v >= series[i - 2] && v >= series[i + 2]) {
+        const t = timeSeries[i];
+        if (!peaks.length || t - peaks[peaks.length - 1] >= minDistance) {
+          peaks.push(t);
+        }
+      }
+    }
+    return peaks;
+  }
+
+  _median(values) {
+    if (!values.length) return NaN;
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    if (sorted.length % 2 === 0) {
+      return (sorted[mid - 1] + sorted[mid]) / 2;
+    }
+    return sorted[mid];
+  }
+
+  _rmssd(ibis) {
+    if (ibis.length < 3) return NaN;
+    let sum = 0;
+    let count = 0;
+    for (let i = 1; i < ibis.length; i++) {
+      const diff = ibis[i] - ibis[i - 1];
+      sum += diff * diff;
+      count++;
+    }
+    return Math.sqrt(sum / Math.max(count, 1)) * 1000;
+  }
+
+  _stressFromRmssd(rmssdMs) {
+    if (!Number.isFinite(rmssdMs)) return NaN;
+    const clamped = Math.max(15, Math.min(100, rmssdMs));
+    return Math.round(100 - ((clamped - 15) / (100 - 15)) * 100);
+  }
+
+  _dispatchStatus(message) {
+    this.dispatchEvent(new CustomEvent('status', { detail: message }));
+  }
+
+  _dispatchError(type, error) {
+    this.dispatchEvent(new CustomEvent('error', { detail: { type, error } }));
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,133 +1,674 @@
-/* --------- Base --------- */
-:root{
-  --bg:#0f172a;
-  --panel:#111827;
-  --card:#0b1220;
-  --text:#e5e7eb;
-  --muted:#94a3b8;
-  --border:#1f2937;
-  --primary:#60a5fa;
-  --accent:#34d399;
-  --danger:#f87171;
-  --warn:#fbbf24;
+:root {
+  --bg: #0b1220;
+  --panel: rgba(17, 24, 39, 0.92);
+  --card: rgba(15, 23, 42, 0.9);
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --border: rgba(148, 163, 184, 0.2);
+  --primary: #60a5fa;
+  --accent: #34d399;
+  --danger: #f87171;
+  --warn: #fbbf24;
 }
 
-*{box-sizing:border-box}
-html,body{height:100%}
-body{
-  margin:0;
-  font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,Arial;
-  background: radial-gradient(1200px 800px at 80% -200px,#172554,var(--bg));
-  color:var(--text);
+* {
+  box-sizing: border-box;
 }
 
-/* --------- Topbar --------- */
-.topbar{
-  display:flex; align-items:center; justify-content:space-between;
-  padding:12px 18px; position:sticky; top:0; z-index:10;
-  background:rgba(17,24,39,.75); backdrop-filter: blur(6px);
-  border-bottom:1px solid var(--border);
-}
-.brand{display:flex; align-items:center; gap:10px; font-weight:700; letter-spacing:.2px;}
-.logo{width:24px; height:24px}
-.nav .link, .nav .primary{
-  margin-left:8px; border:0; padding:8px 12px; border-radius:8px; cursor:pointer;
-  background:transparent; color:var(--text); text-decoration:none; display:inline-flex; align-items:center;
-}
-.nav .link:hover{background:#0b1220}
-.primary{ background:var(--primary); color:#081426; font-weight:700; }
-.ghost{ background:transparent; border:1px solid var(--border); color:var(--text); }
-.xl{ font-size:16px; padding:10px 16px; }
-
-/* --------- Hero --------- */
-main{max-width:1100px; margin:18px auto; padding:0 14px;}
-.hero{ text-align:center; margin:30px auto; max-width:900px;}
-.hero h1{ font-size:42px; line-height:1.15; margin:0 0 12px; }
-.grad{ background:linear-gradient(90deg,#60a5fa,#34d399); -webkit-background-clip:text; background-clip:text; color:transparent; }
-.sub{ color:var(--muted); font-size:18px; }
-.cta{ margin:18px 0; display:flex; gap:12px; justify-content:center; flex-wrap:wrap;}
-.bullets{ list-style:none; padding:0; display:flex; gap:16px; justify-content:center; flex-wrap:wrap; color:var(--muted); }
-.bullets li{ background:rgba(255,255,255,0.04); border:1px solid var(--border); padding:6px 10px; border-radius:999px; font-size:13px; }
-
-/* --------- Features --------- */
-.features{ display:grid; grid-template-columns: repeat(4,1fr); gap:12px; margin:28px 0;}
-@media(max-width:900px){ .features{ grid-template-columns: repeat(2,1fr);} }
-.feature{ background:var(--card); border:1px solid var(--border); border-radius:12px; padding:14px; }
-.feature h3{ margin:0 0 8px; }
-
-/* --------- Cases --------- */
-.cases h2, .pricing h2{ margin-top:20px; }
-.cards{ display:grid; grid-template-columns: repeat(4,1fr); gap:12px; }
-@media(max-width:900px){ .cards{ grid-template-columns: repeat(2,1fr);} }
-.card{ background:var(--panel); border:1px solid var(--border); border-radius:12px; padding:14px; }
-
-/* --------- Pricing --------- */
-.pricing{ margin:26px 0; }
-.tiers{ display:grid; grid-template-columns: repeat(2,1fr); gap:14px; }
-@media(max-width:800px){ .tiers{ grid-template-columns: 1fr; } }
-.tier{ background:var(--card); border:1px solid var(--border); border-radius:14px; padding:16px; }
-.tier h3{ margin:8px 0; }
-.badge{ display:inline-block; padding:4px 8px; border-radius:999px; background:#0f172a; border:1px solid var(--border); font-size:12px; color:var(--muted); }
-.badge.pro{ border-color:#2563eb; color:#93c5fd; }
-.tier ul{ margin:10px 0 16px; padding-left:18px; }
-.lock{ color:var(--muted); font-size:12px; margin-left:6px; }
-.disclaimer{ color:var(--muted); font-size:12px; }
-
-/* --------- Footer --------- */
-.footer{ text-align:center; margin:30px auto; color:var(--muted); }
-
-/* --------- Modal Demo --------- */
-.modal{ position:fixed; inset:0; background:rgba(0,0,0,0.6); display:none; align-items:center; justify-content:center; padding:14px; }
-.modal.show{ display:flex; }
-.modal-dialog{ width:min(1100px, 96vw); background:rgba(17,24,39,.95); border:1px solid var(--border); border-radius:14px; padding:12px; position:relative; }
-.close{ position:absolute; right:10px; top:8px; background:transparent; border:1px solid var(--border); color:var(--text); border-radius:8px; padding:6px 10px; cursor:pointer; }
-
-.demo-layout{ display:grid; grid-template-columns: 520px 1fr; gap:12px; }
-@media(max-width:1000px){ .demo-layout{ grid-template-columns: 1fr; } }
-
-.video-wrap{ position:relative; background:#000; border-radius:12px; overflow:hidden; aspect-ratio:4/3; }
-video{ width:100%; height:100%; object-fit:cover; display:block; }
-#overlay{ position:absolute; inset:0; pointer-events:none; }
-.roi{
-  position:absolute; left:50%; top:22%; transform:translate(-50%,-50%);
-  width:45%; height:18%; border:2px dashed rgba(96,165,250,.85); border-radius:10px;
-  color:#cbd5e1; display:flex; align-items:center; justify-content:center; font-size:12px; background:rgba(59,130,246,.08);
+html,
+body {
+  height: 100%;
 }
 
-.controls{ margin-top:10px; }
-.row{ display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
-.row label{ color:var(--muted); font-size:14px; }
-.row select, .row button{ height:36px; }
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  background: radial-gradient(1200px 800px at 70% -200px, #172554, var(--bg));
+  color: var(--text);
+  line-height: 1.55;
+}
 
-.metrics-col{ background:rgba(11,18,32,.7); border:1px solid var(--border); border-radius:12px; padding:12px; }
-.kpis{ display:grid; grid-template-columns: repeat(2,1fr); gap:10px; }
-.kpi{ background:var(--card); border:1px solid var(--border); border-radius:12px; padding:12px; position:relative; }
-.kpi .label{ color:var(--muted); font-size:13px; }
-.kpi .value{ font-weight:800; font-size:28px; margin-top:6px; display:flex; gap:6px; align-items:baseline; }
-.unit{ color:var(--muted); font-size:14px; }
-.pulse{ position:absolute; width:12px; height:12px; right:12px; top:12px; border-radius:999px; background:#334155; box-shadow:0 0 0 0 rgba(52,211,153,0.6); }
+body.demo-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
 
-.badge{ margin-top:6px; display:inline-block; padding:4px 8px; border-radius:999px; background:#0f172a; border:1px solid var(--border); font-size:12px; }
-.pro-grid{ display:grid; grid-template-columns: repeat(2,1fr); gap:10px; margin-top:10px; }
-.pro-card{ background:var(--panel); border:1px dashed var(--border); border-radius:12px; padding:12px; position:relative; }
-.locked .lock-text{ position:absolute; right:10px; top:10px; font-size:12px; color:#93c5fd; border:1px solid #1f3b7a; padding:2px 6px; border-radius:999px; }
-.actions{ margin-top:10px; display:flex; gap:8px; align-items:center; }
-.muted{ color:var(--muted); }
-.demo-disclaimer{ color:var(--muted); font-size:12px; margin-top:8px; }
+a {
+  color: inherit;
+}
 
-/* --------- Presentation (presentation.html) --------- */
-.slide-shell{ height:100vh; display:flex; flex-direction:column; background: radial-gradient(1200px 800px at 80% -200px,#172554,var(--bg)); }
-.slide-nav{ display:flex; justify-content:space-between; align-items:center; padding:10px 14px; border-bottom:1px solid var(--border); }
-.slide{ flex:1; display:none; align-items:center; justify-content:center; padding:24px; }
-.slide.show{ display:flex; }
-.slide .content{ max-width:900px; text-align:center; }
-.slide h1{ font-size:48px; margin:0 0 10px; }
-.slide h2{ font-size:36px; margin:0 0 10px; }
-.slide p{ color:var(--muted); font-size:18px; }
-.dotbar{ display:flex; gap:8px; justify-content:center; padding:12px; }
-.dot{ width:8px; height:8px; border-radius:999px; background:#1f2937; }
-.dot.active{ background:#60a5fa; }
-.btns{ display:flex; gap:8px; }
-.btn{ background:#0b1220; color:var(--text); border:1px solid var(--border); padding:8px 12px; border-radius:8px; cursor:pointer; }
-.btn.primary{ background:var(--primary); color:#081426; font-weight:800; }
-/* end */
+/* Header */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 24px;
+  background: rgba(12, 18, 32, 0.75);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border);
+}
+
+.site-brand {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.site-name {
+  font-weight: 700;
+  letter-spacing: 0.3px;
+}
+
+.site-tagline {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.demo-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px min(40px, 5vw) 0;
+}
+
+.demo-brand {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.demo-name {
+  font-weight: 700;
+  letter-spacing: 0.3px;
+}
+
+.demo-sub {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.nav-link {
+  text-decoration: none;
+  font-weight: 500;
+  color: var(--muted);
+  padding: 8px 12px;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-link:hover {
+  color: var(--text);
+  background: rgba(96, 165, 250, 0.1);
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+.primary {
+  background: var(--primary);
+  color: #031125;
+  border: none;
+  border-radius: 999px;
+  padding: 9px 18px;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(96, 165, 250, 0.25);
+}
+
+.ghost {
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  padding: 9px 18px;
+}
+
+.xl {
+  font-size: 16px;
+  padding: 12px 22px;
+}
+
+main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 40px 22px 80px;
+}
+
+body.demo-page main {
+  flex: 1;
+  width: min(1100px, 94vw);
+  padding: 48px 0 72px;
+}
+
+.hero {
+  text-align: center;
+  margin-bottom: 56px;
+}
+
+.demo-intro {
+  margin-bottom: 28px;
+  max-width: 760px;
+}
+
+.demo-intro h1 {
+  font-size: clamp(30px, 4.6vw, 46px);
+  margin-bottom: 12px;
+}
+
+.demo-intro p {
+  color: var(--muted);
+  margin-bottom: 16px;
+}
+
+.demo-intro ul {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--muted);
+  display: grid;
+  gap: 6px;
+}
+
+.hero h1 {
+  font-size: clamp(34px, 5vw, 56px);
+  margin: 0 0 16px;
+}
+
+.lead {
+  color: var(--muted);
+  font-size: 18px;
+  max-width: 780px;
+  margin: 0 auto 24px;
+}
+
+.cta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 14px;
+  margin-bottom: 26px;
+}
+
+.highlight-grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.highlight-grid li {
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--muted);
+  text-align: center;
+  font-size: 15px;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+  margin-bottom: 54px;
+}
+
+.demo-panel {
+  background: rgba(12, 18, 32, 0.86);
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  padding: 24px;
+  box-shadow: 0 30px 60px rgba(2, 6, 23, 0.45);
+}
+
+.video-col {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.feature-grid article {
+  padding: 18px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: var(--card);
+}
+
+.feature-grid h3 {
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.feature-grid p {
+  color: var(--muted);
+  margin: 0;
+}
+
+.how-it-works {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 22px;
+  align-items: start;
+  margin-bottom: 64px;
+}
+
+.how-it-works ol {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--muted);
+}
+
+.callout {
+  background: rgba(96, 165, 250, 0.08);
+  border: 1px solid rgba(96, 165, 250, 0.25);
+  border-radius: 16px;
+  padding: 18px;
+  color: #e0f2fe;
+  font-size: 15px;
+}
+
+.sdk-section {
+  background: rgba(8, 13, 24, 0.85);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 32px 28px;
+}
+
+.sdk-section h2 {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.sdk-section p {
+  color: var(--muted);
+}
+
+pre {
+  margin: 20px 0;
+  padding: 18px;
+  background: rgba(2, 6, 14, 0.85);
+  border: 1px solid rgba(8, 47, 73, 0.8);
+  border-radius: 12px;
+  overflow-x: auto;
+}
+
+code {
+  font-family: "Fira Code", "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+  font-size: 14px;
+  color: #bae6fd;
+}
+
+.site-footer {
+  text-align: center;
+  padding: 26px 18px 40px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+/* Modal */
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 7, 18, 0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.modal.show {
+  display: flex;
+}
+
+.modal-dialog {
+  width: min(1080px, 96vw);
+  max-height: 96vh;
+  background: rgba(8, 13, 24, 0.97);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 18px;
+  padding: 18px;
+  position: relative;
+  overflow: auto;
+}
+
+.close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 6px 10px;
+}
+
+.modal-header {
+  margin-bottom: 18px;
+  padding: 0 6px;
+}
+
+.modal-header h2 {
+  margin: 0 0 6px;
+}
+
+.modal-header p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.demo-layout {
+  display: grid;
+  grid-template-columns: 520px 1fr;
+  gap: 18px;
+}
+
+@media (max-width: 1080px) {
+  .demo-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.video-wrap {
+  position: relative;
+  border-radius: 16px;
+  overflow: hidden;
+  aspect-ratio: 4 / 3;
+  background: #000;
+}
+
+video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+#overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.roi {
+  position: absolute;
+  top: 22%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 46%;
+  height: 18%;
+  border: 2px dashed rgba(96, 165, 250, 0.85);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  background: rgba(59, 130, 246, 0.1);
+  color: #e2e8f0;
+}
+
+.controls {
+  margin-top: 14px;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.row label {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+select {
+  height: 38px;
+  padding: 0 10px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: rgba(10, 18, 32, 0.9);
+  color: var(--text);
+}
+
+.metrics-col {
+  background: rgba(11, 18, 32, 0.8);
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+}
+
+.kpi {
+  position: relative;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.9);
+  padding: 14px 16px 18px;
+}
+
+.kpi .label {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.kpi .value {
+  font-size: 30px;
+  font-weight: 700;
+  margin-top: 6px;
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+}
+
+.unit {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.pulse {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  top: 16px;
+  right: 16px;
+  border-radius: 999px;
+  background: #334155;
+  box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.55);
+  transition: box-shadow 0.12s ease;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.badge.subtle {
+  background: rgba(15, 23, 42, 0.75);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  min-height: 24px;
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.demo-disclaimer {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.demo-footer {
+  text-align: center;
+  color: var(--muted);
+  padding: 0 0 32px;
+  font-size: 12px;
+}
+
+.note small {
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  .site-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .site-nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .cta {
+    flex-direction: column;
+  }
+
+  .how-it-works {
+    grid-template-columns: 1fr;
+  }
+
+  .demo-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  body.demo-page main {
+    width: min(1100px, 96vw);
+    padding: 32px 0 48px;
+  }
+
+  .demo-panel {
+    padding: 18px;
+  }
+}
+
+/* Presentation slides */
+.slide-shell {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(1000px 700px at 70% -200px, #172554, var(--bg));
+}
+
+.slide-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(12, 18, 32, 0.8);
+}
+
+.slide-nav strong {
+  font-weight: 600;
+}
+
+.slide-nav .btns {
+  display: flex;
+  gap: 10px;
+}
+
+.slide {
+  flex: 1;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 26px;
+  text-align: center;
+}
+
+.slide.show {
+  display: flex;
+}
+
+.slide .content {
+  max-width: 860px;
+}
+
+.slide h1 {
+  font-size: clamp(38px, 7vw, 56px);
+  margin: 0 0 12px;
+}
+
+.slide h2 {
+  font-size: clamp(28px, 5vw, 42px);
+  margin: 0 0 10px;
+}
+
+.slide p {
+  color: var(--muted);
+  font-size: 18px;
+}
+
+.dotbar {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  padding: 18px;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.3);
+}
+
+.dot.active {
+  background: var(--primary);
+}
+
+.btn {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 8px 14px;
+  text-decoration: none;
+  color: var(--text);
+}
+
+.btn.primary {
+  background: var(--primary);
+  color: #031125;
+  border-color: transparent;
+}

--- a/sw.js
+++ b/sw.js
@@ -1,18 +1,31 @@
-const CACHE = 'vitals-demo-v1';
+const CACHE = 'openvitals-v1';
 const ASSETS = [
-  '/', '/index.html', '/styles.css', '/app.js', '/presentation.html', '/manifest.webmanifest', '/assets/logo.svg'
+  '/',
+  '/index.html',
+  '/demo.html',
+  '/styles.css',
+  '/app.js',
+  '/demo.js',
+  '/vitals-demo.js',
+  '/sdk.js',
+  '/manifest.webmanifest',
 ];
-self.addEventListener('install', e => {
-  e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
-});
-self.addEventListener('activate', e => {
-  e.waitUntil(
-    caches.keys().then(keys => Promise.all(keys.map(k => k !== CACHE && caches.delete(k))))
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE).then((cache) => cache.addAll(ASSETS)).catch(() => {})
   );
 });
-self.addEventListener('fetch', e => {
-  if (e.request.method !== 'GET') return;
-  e.respondWith(
-    caches.match(e.request).then(cached => cached || fetch(e.request))
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(keys.filter((key) => key !== CACHE).map((key) => caches.delete(key))))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then((cached) => cached || fetch(event.request))
   );
 });

--- a/vitals-demo.js
+++ b/vitals-demo.js
@@ -1,0 +1,213 @@
+import { CameraVitalsSDK } from './sdk.js';
+
+export class VitalsDemo {
+  constructor({
+    videoElement,
+    overlayCanvas,
+    startButton,
+    stopButton,
+    cameraSelect,
+    hrEl,
+    stressEl,
+    stressBadge,
+    hrvEl,
+    rrEl,
+    statusEl,
+    qualityEl,
+    pulseDot,
+  }) {
+    this.videoElement = videoElement;
+    this.overlayCanvas = overlayCanvas;
+    this.startButton = startButton;
+    this.stopButton = stopButton;
+    this.cameraSelect = cameraSelect;
+    this.hrEl = hrEl;
+    this.stressEl = stressEl;
+    this.stressBadge = stressBadge;
+    this.hrvEl = hrvEl;
+    this.rrEl = rrEl;
+    this.statusEl = statusEl;
+    this.qualityEl = qualityEl;
+    this.pulseDot = pulseDot;
+
+    this.sdk = new CameraVitalsSDK({
+      videoElement: this.videoElement,
+      overlayCanvas: this.overlayCanvas,
+    });
+
+    this.camerasCache = [];
+
+    this.startMeasurement = this.startMeasurement.bind(this);
+    this.stopMeasurement = this.stopMeasurement.bind(this);
+
+    this.startButton?.addEventListener('click', this.startMeasurement);
+    this.stopButton?.addEventListener('click', this.stopMeasurement);
+
+    this.sdk.addEventListener('status', (event) => {
+      if (this.statusEl) {
+        this.statusEl.textContent = event.detail || '';
+      }
+    });
+
+    this.sdk.addEventListener('error', (event) => {
+      const { type, error } = event.detail || {};
+      console.error('CameraVitalsSDK error:', type, error);
+      if (this.statusEl) {
+        this.statusEl.textContent = 'An error occurred. Check permissions and lighting.';
+      }
+    });
+
+    this.sdk.addEventListener('metrics', (event) => {
+      this.updateMetrics(event.detail || {});
+    });
+
+    this.reset();
+  }
+
+  reset() {
+    if (this.hrEl) this.hrEl.textContent = '–';
+    if (this.stressEl) this.stressEl.textContent = '–';
+    if (this.stressBadge) {
+      this.stressBadge.textContent = '—';
+      this.stressBadge.style.color = '';
+      this.stressBadge.style.borderColor = '';
+    }
+    if (this.hrvEl) this.hrvEl.textContent = '–';
+    if (this.rrEl) this.rrEl.textContent = '–';
+    if (this.qualityEl) {
+      this.qualityEl.textContent = 'Signal quality: —';
+      this.qualityEl.style.borderColor = '';
+    }
+    if (this.pulseDot) {
+      this.pulseDot.style.boxShadow = '0 0 0 0 rgba(52, 211, 153, 0.6)';
+      this.pulseDot.style.background = '#334155';
+    }
+    if (this.statusEl) {
+      this.statusEl.textContent = '';
+    }
+    if (this.startButton) this.startButton.disabled = false;
+    if (this.stopButton) this.stopButton.disabled = true;
+  }
+
+  async refreshCameras({ requestAccess = true } = {}) {
+    if (!this.cameraSelect) return;
+
+    try {
+      this.camerasCache = await this.sdk.listCameras({ requestAccess });
+      this.cameraSelect.innerHTML = '';
+      this.camerasCache.forEach((camera, index) => {
+        const option = document.createElement('option');
+        option.value = camera.deviceId;
+        option.textContent = camera.label || `Camera ${index + 1}`;
+        this.cameraSelect.appendChild(option);
+      });
+
+      const preferred = this.camerasCache.find((camera) =>
+        /front|user|frontal|face/i.test(camera.label || '')
+      );
+      if (preferred) {
+        this.cameraSelect.value = preferred.deviceId;
+      }
+
+      if (!this.camerasCache.length) {
+        if (this.statusEl) {
+          this.statusEl.textContent = 'No cameras detected. Connect a camera and reload.';
+        }
+        if (this.startButton) this.startButton.disabled = true;
+      } else if (this.stopButton?.disabled) {
+        if (this.startButton) this.startButton.disabled = false;
+      }
+    } catch (error) {
+      if (this.statusEl) {
+        this.statusEl.textContent = 'Unable to list cameras. Check permissions and HTTPS.';
+      }
+    }
+  }
+
+  async startMeasurement() {
+    if (this.startButton) this.startButton.disabled = true;
+    if (this.stopButton) this.stopButton.disabled = false;
+    if (this.statusEl) this.statusEl.textContent = 'Starting camera…';
+
+    try {
+      await this.sdk.start({ deviceId: this.cameraSelect?.value || undefined });
+    } catch (error) {
+      if (this.startButton) this.startButton.disabled = false;
+      if (this.stopButton) this.stopButton.disabled = true;
+      if (this.statusEl) {
+        this.statusEl.textContent = 'Unable to start capture. Verify camera permissions and availability.';
+      }
+    }
+  }
+
+  async stopMeasurement() {
+    if (this.startButton) this.startButton.disabled = false;
+    if (this.stopButton) this.stopButton.disabled = true;
+    await this.sdk.stop();
+  }
+
+  async stop() {
+    await this.sdk.stop();
+    if (this.startButton) this.startButton.disabled = false;
+    if (this.stopButton) this.stopButton.disabled = true;
+  }
+
+  updateMetrics({ heartRate, stressScore, hrvMs, breathingRate, beatPhase, signalQuality }) {
+    if (Number.isFinite(heartRate)) {
+      if (this.hrEl) this.hrEl.textContent = heartRate;
+    } else if (this.hrEl) {
+      this.hrEl.textContent = '–';
+    }
+
+    if (Number.isFinite(stressScore)) {
+      if (this.stressEl) this.stressEl.textContent = stressScore;
+      if (this.stressBadge) {
+        this.stressBadge.textContent = stressScore >= 66 ? 'High' : stressScore >= 33 ? 'Medium' : 'Low';
+        const color = stressScore >= 66 ? '#f87171' : stressScore >= 33 ? '#fbbf24' : '#34d399';
+        const border = stressScore >= 66 ? '#fca5a5' : stressScore >= 33 ? '#fde68a' : '#86efac';
+        this.stressBadge.style.color = border;
+        this.stressBadge.style.borderColor = color;
+      }
+    } else {
+      if (this.stressEl) this.stressEl.textContent = '–';
+      if (this.stressBadge) {
+        this.stressBadge.textContent = '—';
+        this.stressBadge.style.color = '';
+        this.stressBadge.style.borderColor = '';
+      }
+    }
+
+    if (Number.isFinite(hrvMs)) {
+      if (this.hrvEl) this.hrvEl.textContent = hrvMs;
+    } else if (this.hrvEl) {
+      this.hrvEl.textContent = '–';
+    }
+
+    if (Number.isFinite(breathingRate)) {
+      if (this.rrEl) this.rrEl.textContent = breathingRate;
+    } else if (this.rrEl) {
+      this.rrEl.textContent = '–';
+    }
+
+    if (beatPhase != null && Number.isFinite(beatPhase) && this.pulseDot) {
+      const scale = Math.max(0, 1 - Math.min(beatPhase, 1));
+      const radius = Math.round(scale * 18);
+      this.pulseDot.style.boxShadow = `0 0 0 ${radius}px rgba(52,211,153,0.65)`;
+      this.pulseDot.style.background = '#34d399';
+    } else if (this.pulseDot) {
+      this.pulseDot.style.boxShadow = '0 0 0 0 rgba(52,211,153,0.6)';
+      this.pulseDot.style.background = '#334155';
+    }
+
+    if (Number.isFinite(signalQuality)) {
+      const qualityPercent = Math.round(signalQuality * 100);
+      if (this.qualityEl) {
+        this.qualityEl.textContent = `Signal quality: ${qualityPercent}%`;
+        this.qualityEl.style.borderColor = signalQuality > 0.6 ? '#34d399' : signalQuality > 0.3 ? '#fbbf24' : '#f87171';
+      }
+    } else if (this.qualityEl) {
+      this.qualityEl.textContent = 'Signal quality: —';
+      this.qualityEl.style.borderColor = '';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `demo.html` page wired to the camera experience so it can run outside the landing modal
- refactor the UI logic into a shared `VitalsDemo` controller consumed by both the landing page and standalone demo
- expand styling, navigation, documentation, and cached assets to reflect the new demo entry point

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cdba42b0708330b8bddda42947283e